### PR TITLE
refactor(log): controlable log

### DIFF
--- a/cryptos/aes.go
+++ b/cryptos/aes.go
@@ -5,6 +5,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"fmt"
+
+	"github.com/cooomma/fairplay-ksm/logger"
 )
 
 func pkcs5Padding(ciphertext []byte, blockSize int) []byte {
@@ -21,7 +23,7 @@ func pkcs5UnPadding(origData []byte) []byte {
 func AESCBCEncrypt(key, iv, plainText []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	mode := cipher.NewCBCEncrypter(block, iv)
@@ -37,9 +39,8 @@ func AESCBCEncrypt(key, iv, plainText []byte) ([]byte, error) {
 
 // AESCBCDecrypt is given key, iv to decrypt the cipherText in AES CBC way.
 func AESCBCDecrypt(key, iv, cipherText []byte) ([]byte, error) {
-
 	if len(cipherText) == 0 {
-		panic("ciphertext can't be plain")
+		return nil, fmt.Errorf("ciphertext can't be plain")
 	}
 
 	block, err := aes.NewCipher(key)
@@ -50,7 +51,7 @@ func AESCBCDecrypt(key, iv, cipherText []byte) ([]byte, error) {
 	mode := cipher.NewCBCDecrypter(block, iv)
 	plainText := make([]byte, len(cipherText))
 	mode.CryptBlocks(plainText, cipherText)
-	fmt.Println("AES-CBC Decrpypt: PlainText Length: ", len(plainText))
+	logger.Println("AES-CBC Decrpypt: PlainText Length:", len(plainText))
 	if len(cipherText)%aes.BlockSize == 0 {
 		return plainText, nil
 	}
@@ -59,9 +60,9 @@ func AESCBCDecrypt(key, iv, cipherText []byte) ([]byte, error) {
 
 // AESECBEncrypt is given key to encrypt the plainText in AES ECB way.
 func AESECBEncrypt(key, plainText []byte) ([]byte, error) {
-	fmt.Println("AES-ECB Encrpypt: PlainText Length: ", len(plainText))
+	logger.Println("AES-ECB Encrpypt: PlainText Length:", len(plainText))
 	if len(plainText)%aes.BlockSize != 0 {
-		panic("Need a multiple of the blocksize")
+		return nil, fmt.Errorf("need a multiple of the blocksize")
 	}
 	block, err := aes.NewCipher(key)
 	if err != nil {
@@ -80,9 +81,9 @@ func AESECBEncrypt(key, plainText []byte) ([]byte, error) {
 
 // AESECBDecrypt is given key to decrypt the cipherText in AES ECB way.
 func AESECBDecrypt(key, cipherText []byte) ([]byte, error) {
-	fmt.Println("AES-ECB: cipherText Length: ", len(cipherText))
+	logger.Println("AES-ECB: cipherText Length:", len(cipherText))
 	if len(cipherText)%aes.BlockSize != 0 {
-		panic("Input not full blocks")
+		return nil, fmt.Errorf("input not full blocks")
 	}
 
 	block, err := aes.NewCipher(key)

--- a/cryptos/key.go
+++ b/cryptos/key.go
@@ -5,12 +5,13 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"fmt"
 )
 
 func DecryptPriKey(prikey, passphrase []byte) (*rsa.PrivateKey, error) {
 	priPem, _ := pem.Decode(prikey)
 	if priPem.Type != "RSA PRIVATE KEY" {
-		panic("Private Key is not RSA Private Key.")
+		return nil, fmt.Errorf("private key is not RSA Private Key")
 	}
 
 	var decryptedPriKeyByte []byte
@@ -44,11 +45,11 @@ func ParseASk(ask string) ([]byte, error) {
 func ParsePublicCertification(pubCert []byte) (*rsa.PublicKey, error) {
 	block, _ := pem.Decode(pubCert)
 	if block == nil {
-		panic("failed to parse certificate PEM")
+		return nil, fmt.Errorf("failed to parse certificate PEM")
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		panic("failed to parse certificate: " + err.Error())
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
 	}
 	return cert.PublicKey.(*rsa.PublicKey), nil
 }

--- a/cryptos/oaep.go
+++ b/cryptos/oaep.go
@@ -5,13 +5,14 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
-	"errors"
 	"fmt"
+
+	"github.com/cooomma/fairplay-ksm/logger"
 )
 
 func OAEPDecrypt(pub *rsa.PublicKey, pri *rsa.PrivateKey, cipherText []byte) ([]byte, error) {
 	if len(cipherText) == 0 {
-		return nil, errors.New("cipherText can not be empty string.")
+		return nil, fmt.Errorf("cipherText can not be empty string")
 	}
 	buffer := bytes.Buffer{}
 	for _, cipherTextBlock := range grouping(cipherText, len(pub.N.Bytes())) {
@@ -27,7 +28,7 @@ func OAEPDecrypt(pub *rsa.PublicKey, pri *rsa.PrivateKey, cipherText []byte) ([]
 
 func grouping(src []byte, size int) [][]byte {
 	var groups [][]byte
-	fmt.Println(size)
+	logger.Println(size)
 	srcSize := len(src)
 	if srcSize <= size {
 		groups = append(groups, src)

--- a/ksm/d_function.go
+++ b/ksm/d_function.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/cooomma/fairplay-ksm/cryptos"
 )
@@ -106,7 +107,7 @@ func (d DFunction) ComputeHashValue(R2 []byte) ([]byte, error) {
 	hh := h.Sum(nil)
 
 	if len(hh) != 20 {
-		panic("hash value must length 20  expected.")
+		return nil, fmt.Errorf("hash value length must be 20, but %d", len(hh))
 	}
 
 	return hh[0:16], nil

--- a/ksm/tllv.go
+++ b/ksm/tllv.go
@@ -4,7 +4,8 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
-	"fmt"
+
+	"github.com/cooomma/fairplay-ksm/logger"
 )
 
 // TLLVBlock represents a TLLV block structure.
@@ -66,8 +67,8 @@ func (t *TLLVBlock) check() error {
 		return errors.New("tag not found")
 	}
 	if len(t.Value) == 0 {
-		fmt.Printf("tag: %x :value not found\n", t.Tag)
-		fmt.Printf("tag.ValueLength: %x \n", t.ValueLength)
+		logger.Printf("tag: %x :value not found\n", t.Tag)
+		logger.Printf("tag.ValueLength: %x \n", t.ValueLength)
 
 		//return fmt.Errorf("tag: %x :value not found", t.Tag)
 	}
@@ -99,7 +100,7 @@ type CkcDataIv struct {
 	IV []byte
 }
 
-//CkcEncryptedPayload represents a ckc encrypted payload structure.
+// CkcEncryptedPayload represents a ckc encrypted payload structure.
 type CkcEncryptedPayload struct {
 	Payload []byte
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,25 @@
+package logger
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+var logger *log.Logger
+
+func init() {
+	logger = log.New(os.Stdout, "", 0)
+}
+
+func Println(args ...interface{}) {
+	logger.Println(args...)
+}
+
+func Printf(format string, args ...interface{}) {
+	logger.Println(fmt.Sprintf(format, args...))
+}
+
+func SetLogger(l *log.Logger) {
+	logger = l
+}


### PR DESCRIPTION
In the cryptos and kms packages, fmt.Println and fmt.Printf are used to print logs, making it difficult to control the log level from users.
To enable control over log printing, I want to make the logger replaceable.
